### PR TITLE
(GH-96) Add Ref property to CreateReleaseRequest

### DIFF
--- a/src/GitLabApiClient/Models/Releases/Requests/CreateReleaseRequest.cs
+++ b/src/GitLabApiClient/Models/Releases/Requests/CreateReleaseRequest.cs
@@ -29,5 +29,8 @@ namespace GitLabApiClient.Models.Releases.Requests
             Description = description;
             ReleasedAt = (releasedAt == null) ? DateTime.Now : releasedAt;
         }
+        
+        [JsonProperty("ref")]
+        public string Ref { get; set; }
     }
 }


### PR DESCRIPTION
As documented here:

https://docs.gitlab.com/ee/api/releases/#create-a-release

When creating a GitLab release, there is additional property called `Ref` which is used when the Tag that the Release is targeting doesn't exist yet.  This Ref can be a SHA for a commit, another tag, or a branch name.  In the testing that I have done, the tag_name property is still required, so I don't think we need to create any additional constructors, only have the ability to set the `Ref` property when required.

Fixes #96